### PR TITLE
Change method of playing videos

### DIFF
--- a/resources/lib/entries.py
+++ b/resources/lib/entries.py
@@ -35,6 +35,7 @@ def make_entries_list(url):
                                         iconImage=p.get_thumbnail(),
                                         thumbnailImage=p.get_thumbnail())
             listitem.setInfo('video', p.get_xbmc_list_item())
+            listitem.setProperty('IsPlayable', 'true')
 
             if hasattr(listitem, 'addStreamInfo'):
                 listitem.addStreamInfo('audio', p.get_xbmc_audio_stream_info())
@@ -45,7 +46,7 @@ def make_entries_list(url):
 
             # Add the program item to the list
             ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url,
-                                             listitem=listitem, isFolder=False, 
+                                             listitem=listitem, isFolder=False,
                                              totalItems=len(programs))
 
         xbmcplugin.endOfDirectory(handle=int(sys.argv[1]), succeeded=ok)

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -16,6 +16,7 @@
 #  along with this addon. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import sys
 import classes
 import comm
 import config
@@ -23,6 +24,7 @@ import utils
 import xbmc
 import xbmcgui
 import xbmcaddon
+import xbmcplugin
 
 def play(url):
     addon = xbmcaddon.Addon(config.ADDON_ID)
@@ -40,13 +42,14 @@ def play(url):
 
         listitem=xbmcgui.ListItem(label=p.get_list_title(),
                                   iconImage=p.thumbnail,
-                                  thumbnailImage=p.thumbnail)
+                                  thumbnailImage=p.thumbnail,
+                                  path=stream_url)
         listitem.setInfo('video', p.get_xbmc_list_item())
 
         if hasattr(listitem, 'addStreamInfo'):
             listitem.addStreamInfo('audio', p.get_xbmc_audio_stream_info())
             listitem.addStreamInfo('video', p.get_xbmc_video_stream_info())
-    
-        xbmc.Player().play(stream_url, listitem)
+
+        xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, listitem=listitem)
     except:
         utils.handle_error("Unable to play video")


### PR DESCRIPTION
Use xbmcplugin.setResolvedUrl instead of xbmc.Player().play method. This fixes bad behavior when using 'Play from here' context menu option.